### PR TITLE
Integrate tracking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .next
 .vscode
 /node_modules
+.env*.local

--- a/articles/soil-carbon-comment/index.md
+++ b/articles/soil-carbon-comment/index.md
@@ -62,7 +62,7 @@ Any protocol for soil carbon crediting needs to start by appreciating the comple
 
 ## Our comments
 
-Given the enormous challenges in designing a carbon offset protocol to quantify and credit soil carbon storage, we were interested to see the Climate Action Reserve take this problem on. We reviewed the draft protocol and highlight two sets of issues here. See our <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/Soil-Carbon-Comment-Letter-05-18-2020.pdf'>comment letter</Link> for details and check out comments posted by other groups at the [protocol website](https://www.climateactionreserve.org/how/protocols/soil-enrichment/).
+Given the enormous challenges in designing a carbon offset protocol to quantify and credit soil carbon storage, we were interested to see the Climate Action Reserve take this problem on. We reviewed the draft protocol and highlight two sets of issues here. See our <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/Soil-Carbon-Comment-Letter-05-18-2020.pdf' tracking>comment letter</Link> for details and check out comments posted by other groups at the [protocol website](https://www.climateactionreserve.org/how/protocols/soil-enrichment/).
 
 ### Conflict of interest
 
@@ -121,7 +121,7 @@ Meanwhile, any efforts built around carbon offset credits should be transparent,
   AUG 25 2020
 </Box>
 
-After reviewing an updated version of the draft protocol, we submitted a second <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/Soil-Carbon-Comment-Letter-08-25-2020.pdf'>comment letter</Link> on remaining concerns and additional issues.
+After reviewing an updated version of the draft protocol, we submitted a second <Link href='https://carbonplan-assets.s3.amazonaws.com/docs/Soil-Carbon-Comment-Letter-08-25-2020.pdf' tracking>comment letter</Link> on remaining concerns and additional issues.
 
 </Endnote>
 

--- a/components/entry.js
+++ b/components/entry.js
@@ -43,7 +43,7 @@ const Entry = ({ info, first, final }) => {
             sx={{ display: ['initial', 'none', 'none', 'none'] }}
           >
             {icon && (
-              <Link href={links[0].href}>
+              <Link href={links[0].href} tracking>
                 <Icon icon={icon} color={color} />
               </Link>
             )}
@@ -102,6 +102,7 @@ const Entry = ({ info, first, final }) => {
                 }}
                 tabIndex='-1'
                 href={links[0].href}
+                tracking
               >
                 {indexTitle || title}
               </Link>
@@ -170,7 +171,7 @@ const Entry = ({ info, first, final }) => {
                 ))}
             </Box>
             {icon && (
-              <Link tabIndex='-1' href={links[0].href}>
+              <Link tabIndex='-1' href={links[0].href} tracking>
                 <Icon icon={icon} color={color} />
               </Link>
             )}
@@ -204,6 +205,7 @@ function LinkGroup({ links }) {
           mr: [4, 4, 4, 5],
         }}
         suffix={<RotatingArrow />}
+        tracking
       >
         {link.label}
       </Button>

--- a/components/links.js
+++ b/components/links.js
@@ -20,6 +20,7 @@ const Links = ({ data, color }) => {
               mb: [1, 0, 0, 0],
             }}
             suffix={<RotatingArrow />}
+            tracking
           >
             {d.label}
           </Button>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "@carbonplan/charts": "^2.0.0",
-        "@carbonplan/components": "^9.1.0",
+        "@carbonplan/components": "^10.0.0",
         "@carbonplan/icons": "^1.0.0",
         "@carbonplan/theme": "^7.0.0",
         "@mdx-js/loader": "^1.6.22",
@@ -391,9 +391,9 @@
       }
     },
     "node_modules/@carbonplan/components": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-9.1.0.tgz",
-      "integrity": "sha512-LNabdmK4AG2zBnxywmNyIWVZJHIMT0LaLy3TVsclfpDitQ3vy8gKuZ1zKw/qlAM3jnZDOFwsZV4yBL3Guzwirg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-10.0.0.tgz",
+      "integrity": "sha512-+xm639+Ia5oD++VwszOs0KqFCWhk/qMWXCyRzkd/Iwnv13pdQlwNEYaRTxQNEYiZ/ZqwyQ4xD2zrKKKzYtiLAw==",
       "dependencies": {
         "@carbonplan/emoji": "^1.0.0",
         "@carbonplan/icons": "^1.0.0",
@@ -6968,9 +6968,9 @@
       }
     },
     "@carbonplan/components": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-9.1.0.tgz",
-      "integrity": "sha512-LNabdmK4AG2zBnxywmNyIWVZJHIMT0LaLy3TVsclfpDitQ3vy8gKuZ1zKw/qlAM3jnZDOFwsZV4yBL3Guzwirg==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@carbonplan/components/-/components-10.0.0.tgz",
+      "integrity": "sha512-+xm639+Ia5oD++VwszOs0KqFCWhk/qMWXCyRzkd/Iwnv13pdQlwNEYaRTxQNEYiZ/ZqwyQ4xD2zrKKKzYtiLAw==",
       "requires": {
         "@carbonplan/emoji": "^1.0.0",
         "@carbonplan/icons": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/carbonplan/research#readme",
   "dependencies": {
     "@carbonplan/charts": "^2.0.0",
-    "@carbonplan/components": "^9.1.0",
+    "@carbonplan/components": "^10.0.0",
     "@carbonplan/icons": "^1.0.0",
     "@carbonplan/theme": "^7.0.0",
     "@mdx-js/loader": "^1.6.22",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -7,7 +7,7 @@ class MyDocument extends Document {
     return (
       <Html lang='en' className='no-focus-outline'>
         <Head>
-          <Tracking />
+          <Tracking id={process.env.GA_TRACKING_ID} />
         </Head>
         <body>
           <InitializeColorMode />

--- a/tools/dac-calculator/components/methods.js
+++ b/tools/dac-calculator/components/methods.js
@@ -1,5 +1,5 @@
-import { Box, Heading, Text, Link, Themed } from 'theme-ui'
-import { default as NextLink } from 'next/link'
+import { Box, Text, Themed } from 'theme-ui'
+import { Link } from '@carbonplan/components'
 
 const Methods = () => {
   return (
@@ -17,7 +17,7 @@ const Methods = () => {
       </Text>
       <Themed.p>
         This calculator computes the{' '}
-        <Link href='https://cdrprimer.org/read/chapter-4#sec-4-3'>
+        <Link href='https://cdrprimer.org/read/chapter-4#sec-4-3' tracking>
           net removed cost
         </Link>{' '}
         ($/tCO₂eq) of carbon removal for a hypothetical DAC facility coupled to
@@ -45,12 +45,16 @@ const Methods = () => {
       </Themed.p>
       <Themed.p>
         The entire model is implemented natively in JavaScript and{' '}
-        <Link href='https://github.com/carbonplan/research/tree/main/tools/dac-calculator'>
+        <Link
+          tracking
+          href='https://github.com/carbonplan/research/tree/main/tools/dac-calculator'
+        >
           available on Github
         </Link>
         , and a Python version is under development. The model is based directly
         on a{' '}
         <Link
+          tracking
           href={
             'https://www.frontiersin.org/articles/10.3389/fclim.2020.618644/full'
           }
@@ -63,10 +67,8 @@ const Methods = () => {
       </Themed.p>
       <Themed.p>
         Read our{' '}
-        <NextLink href={'/research/dac-calculator-explainer'} passHref={true}>
-          <Link>article</Link>
-        </NextLink>{' '}
-        for more information.
+        <Link href={'/research/dac-calculator-explainer'}>article</Link> for
+        more information.
       </Themed.p>
     </Box>
   )

--- a/tools/dac-calculator/index.js
+++ b/tools/dac-calculator/index.js
@@ -26,6 +26,7 @@ const Index = () => {
         href={
           'https://www.frontiersin.org/articles/10.3389/fclim.2020.618644/full'
         }
+        tracking
       >
         paper
       </Link>{' '}


### PR DESCRIPTION
- depends on https://github.com/carbonplan/components/pull/92
- reinstate link-tracking that was afforded by deprecated `WrappedLink` and `TaggedLink` components before https://github.com/carbonplan/research/pull/158 
- also track links rendered on article pages
- pass Google Analytics ID to `Tracking` from environment variable