### PR TITLE
'Read publication' -> 'Read paper'

### DIFF
--- a/articles/forest-offsets-explainer/index.md
+++ b/articles/forest-offsets-explainer/index.md
@@ -38,7 +38,7 @@ export const meta = {
   icon: 'article-008/ash-small',
   links: [
     {
-      label: 'Read publication',
+      label: 'Read paper',
       href: 'https://doi.org/10.1111/gcb.15943',
     },
     {

--- a/contents.js
+++ b/contents.js
@@ -144,7 +144,7 @@ const contents = [
     icon: 'article-008/ash-small',
     links: [
       { label: 'Read article', href: '/research/forest-offsets-explainer' },
-      { label: 'Read publication', href: 'https://doi.org/10.1111/gcb.15943' },
+      { label: 'Read paper', href: 'https://doi.org/10.1111/gcb.15943' },
       { label: 'Browse map', href: '/research/forest-offsets' },
       {
         label: 'Press coverage',


### PR DESCRIPTION
- update GCB link again to use "Read paper" label consistent with other entries
- now all links are one of:
  - `Read article`
  - `Read preprint`
  - `Read paper`
  - `Read comment letter[...]`