### PR TITLE
Use @carbonplan/charts `Donut` component

### DIFF
--- a/articles/dac-calculator-explainer/components/cost-summary.js
+++ b/articles/dac-calculator-explainer/components/cost-summary.js
@@ -26,7 +26,12 @@ const sx = {
     color: 'purple',
     fontSize: [5, 5, 5, 6],
     ml: [2],
-    mb: [2],
+    mb: ['11px'],
+  },
+  donut: {
+    width: ['85%', '85%', '85%', '100%'],
+    ml: ['4px'],
+    mb: ['10px'],
   },
 }
 
@@ -73,19 +78,25 @@ const CostSummary = ({
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>NGCC</Box>
           <Box sx={sx.cost}>${NGCCTotalCost.toFixed(0)}</Box>
-          <Donut results={NGCCResults} maxWidth={125} />
+          <Box sx={sx.donut}>
+            <Donut results={NGCCResults} initWidth={125} />
+          </Box>
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Wind</Box>
           <Box sx={sx.cost}>${windTotalCost.toFixed(0)}</Box>
-          <Donut results={windResults} maxWidth={125} />
+          <Box sx={sx.donut}>
+            <Donut results={windResults} initWidth={125} />
+          </Box>
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Solar</Box>
           <Box sx={sx.cost}>${solarTotalCost.toFixed(0)}</Box>
-          <Donut results={solarResults} maxWidth={125} />
+          <Box sx={sx.donut}>
+            <Donut results={solarResults} initWidth={125} />
+          </Box>
         </Box>
         <Box sx={{ position: 'relative' }}>
           <Legend />

--- a/articles/dac-calculator-explainer/components/cost-summary.js
+++ b/articles/dac-calculator-explainer/components/cost-summary.js
@@ -73,19 +73,19 @@ const CostSummary = ({
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>NGCC</Box>
           <Box sx={sx.cost}>${NGCCTotalCost.toFixed(0)}</Box>
-          <Donut results={NGCCResults} initWidth={125} />
+          <Donut results={NGCCResults} maxWidth={125} />
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Wind</Box>
           <Box sx={sx.cost}>${windTotalCost.toFixed(0)}</Box>
-          <Donut results={windResults} initWidth={125} />
+          <Donut results={windResults} maxWidth={125} />
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Solar</Box>
           <Box sx={sx.cost}>${solarTotalCost.toFixed(0)}</Box>
-          <Donut results={solarResults} initWidth={125} />
+          <Donut results={solarResults} maxWidth={125} />
         </Box>
         <Box sx={{ position: 'relative' }}>
           <Legend />

--- a/articles/dac-calculator-explainer/components/cost-summary.js
+++ b/articles/dac-calculator-explainer/components/cost-summary.js
@@ -29,7 +29,6 @@ const sx = {
     mb: ['11px'],
   },
   donut: {
-    width: ['85%', '85%', '85%', '100%'],
     ml: ['4px'],
     mb: ['10px'],
   },
@@ -78,25 +77,19 @@ const CostSummary = ({
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>NGCC</Box>
           <Box sx={sx.cost}>${NGCCTotalCost.toFixed(0)}</Box>
-          <Box sx={sx.donut}>
-            <Donut results={NGCCResults} initWidth={125} />
-          </Box>
+          <Donut results={NGCCResults} initWidth={125} sx={sx.donut} />
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Wind</Box>
           <Box sx={sx.cost}>${windTotalCost.toFixed(0)}</Box>
-          <Box sx={sx.donut}>
-            <Donut results={windResults} initWidth={125} />
-          </Box>
+          <Donut results={windResults} initWidth={125} sx={sx.donut} />
         </Box>
         <Box sx={{ textAlign: 'left' }}>
           <Divider sx={{ mt: [0], mr: [0, 0, 3, 3] }} />
           <Box sx={sx.title}>Solar</Box>
           <Box sx={sx.cost}>${solarTotalCost.toFixed(0)}</Box>
-          <Box sx={sx.donut}>
-            <Donut results={solarResults} initWidth={125} />
-          </Box>
+          <Donut results={solarResults} initWidth={125} sx={sx.donut} />
         </Box>
         <Box sx={{ position: 'relative' }}>
           <Legend />

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -25,13 +25,14 @@ const Donut = ({ results, maxWidth, center = false }) => {
         width: '100%',
         maxWidth: center ? undefined : maxWidth,
         height: maxWidth,
+        ml: center ? undefined : 1,
       }}
     >
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
           <DonutComponent
             data={values}
-            innerRadius={0.26}
+            innerRadius={0.24}
             color={disabled ? 'gray' : 'purple'}
           />
         </Plot>

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -31,6 +31,7 @@ const DonutChart = ({ results, maxWidth, center = false }) => {
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
           <Donut
+            range={[0.32, 1]}
             data={values}
             innerRadius={0.24}
             color={disabled ? 'gray' : 'purple'}

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -1,7 +1,7 @@
 import { Box } from 'theme-ui'
-import { Chart, Plot, Donut as DonutComponent } from '@carbonplan/charts'
+import { Chart, Plot, Donut } from '@carbonplan/charts'
 
-const Donut = ({ results, maxWidth, center = false }) => {
+const DonutChart = ({ results, maxWidth, center = false }) => {
   const disabled = results['Total Cost [$/tCO2]'] === 'N/A'
 
   const values = []
@@ -30,7 +30,7 @@ const Donut = ({ results, maxWidth, center = false }) => {
     >
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
-          <DonutComponent
+          <Donut
             data={values}
             innerRadius={0.24}
             color={disabled ? 'gray' : 'purple'}
@@ -41,4 +41,4 @@ const Donut = ({ results, maxWidth, center = false }) => {
   )
 }
 
-export default Donut
+export default DonutChart

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -56,7 +56,6 @@ const DonutChart = ({ results, initWidth, sx }) => {
         <Chart padding={{ left: 0, bottom: 0 }}>
           <Plot square>
             <Donut
-              range={[0.32, 1]}
               data={values}
               innerRadius={0.23}
               color={disabled ? 'gray' : 'purple'}

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -1,150 +1,41 @@
-import { useEffect, useState, useRef } from 'react'
-import { Vega } from 'react-vega'
-import { useThemeUI, Box } from 'theme-ui'
-var vegaLite = require('vega-lite')
+import { Box } from 'theme-ui'
+import { Chart, Plot, Donut as DonutComponent } from '@carbonplan/charts'
 
-const Donut = ({ results, initWidth, innerRadius }) => {
-  const [spec, setSpec] = useState(null)
-  const [loaded, setLoaded] = useState(false)
-  const [width, setWidth] = useState(null)
-  const container = useRef(null)
-  const { theme } = useThemeUI()
-  const { rawColors: colors } = theme
-
-  const updateWidth = (node) => {
-    if (container.current) {
-      const newWidth = container.current.offsetWidth * 0.85
-      if (newWidth < initWidth) {
-        setWidth(newWidth)
-      } else {
-        setWidth(initWidth)
-      }
-    }
-  }
-
-  useEffect(() => {
-    updateWidth(container)
-  }, [container.current])
-
-  useEffect(() => {
-    let id = null
-    const listener = () => {
-      clearTimeout(id)
-      id = setTimeout(() => {
-        updateWidth(container)
-      }, 150)
-    }
-    window.addEventListener('resize', listener)
-    return () => {
-      window.removeEventListener('resize', listener)
-    }
-  }, [])
-
-  useEffect(() => {
-    const config = {
-      background: null,
-      cursor: 'pointer',
-      view: {
-        stroke: null,
-      },
-    }
-
-    const spec = {
-      data: {
-        name: 'values',
-      },
-      mark: {
-        type: 'arc',
-        innerRadius: width * 0.2333,
-      },
-      encoding: {
-        theta: {
-          field: 'fraction',
-          type: 'quantitative',
-          scale: { domain: [0, 1] },
-        },
-        opacity: {
-          field: 'index',
-          type: 'quantitative',
-          scale: { domain: [0, 3], range: [0.3, 0.9] },
-          legend: null,
-        },
-        color: {
-          field: 'color',
-          type: 'quantitative',
-          scale: {
-            domain: [0, 1],
-            range: [colors.secondary, colors.purple],
-          },
-          legend: null,
-        },
-      },
-    }
-
-    setSpec(vegaLite.compile(spec, { config: config }).spec)
-    setLoaded(true)
-  }, [theme, width])
-
+const Donut = ({ results, maxWidth, center = false }) => {
   const disabled = results['Total Cost [$/tCO2]'] === 'N/A'
 
-  const values = [
-    {
-      category: 'CAPITAL RECOVERY',
-      index: disabled ? 1 : 0,
-      color: disabled ? 0 : 1,
-      value: results['Capital Recovery [$/tCO2eq]'],
-      fraction: disabled
-        ? 1
-        : results['Capital Recovery [$/tCO2eq]'] /
-          results['Total Cost [$/tCO2]'],
-    },
-    {
-      category: 'FIXED O&M',
-      index: 1,
-      color: 1,
-      value: results['Fixed O&M [$/tCO2eq]'],
-      fraction: disabled
-        ? 0
-        : results['Fixed O&M [$/tCO2eq]'] / results['Total Cost [$/tCO2]'],
-    },
-    {
-      category: 'VARIABLE O&M',
-      index: 3,
-      color: 1,
-      value: results['Variable O&M [$/tCO2eq]'],
-      fraction: disabled
-        ? 0
-        : results['Variable O&M [$/tCO2eq]'] / results['Total Cost [$/tCO2]'],
-    },
-  ]
+  const values = []
 
-  if (results['Natural Gas Cost [$/tCO2]'] > 0) {
-    values.push({
-      category: 'NATURAL GAS',
-      index: 2,
-      color: 1,
-      value: results['Natural Gas Cost [$/tCO2]'],
-      fraction: disabled
-        ? 0
-        : results['Natural Gas Cost [$/tCO2]'] / results['Total Cost [$/tCO2]'],
-    })
+  if (disabled) {
+    values.push(1)
+  } else {
+    values.push(
+      results['Capital Recovery [$/tCO2eq]'],
+      results['Fixed O&M [$/tCO2eq]'],
+      results['Variable O&M [$/tCO2eq]']
+    )
+    if (results['Natural Gas Cost [$/tCO2]'] > 0) {
+      values.push(results['Natural Gas Cost [$/tCO2]'])
+    }
   }
 
-  const height = width
-
   return (
-    <Box ref={container} sx={{ width: '100%' }}>
-      {loaded && width && (
-        <Vega
-          width={width}
-          height={height}
-          data={{ values: values }}
-          renderer={'svg'}
-          actions={false}
-          spec={spec}
-        />
-      )}
-      {(!loaded || !width) && <Box sx={{ height: height + 14 }}></Box>}
+    <Box
+      sx={{
+        width: '100%',
+        maxWidth: center ? undefined : maxWidth,
+        height: maxWidth,
+      }}
+    >
+      <Chart padding={{ left: 0, bottom: 0 }}>
+        <Plot square>
+          <DonutComponent
+            data={values}
+            innerRadius={0.26}
+            color={disabled ? 'gray' : 'purple'}
+          />
+        </Plot>
+      </Chart>
     </Box>
   )
 }

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -8,7 +8,7 @@ const DonutChart = ({ results, initWidth, sx }) => {
 
   const updateWidth = () => {
     if (container.current) {
-      const newWidth = container.current.offsetWidth
+      const newWidth = container.current.offsetWidth * 0.85
       if (newWidth < initWidth) {
         setWidth(newWidth)
       } else {

--- a/articles/dac-calculator-explainer/components/donut.js
+++ b/articles/dac-calculator-explainer/components/donut.js
@@ -1,9 +1,34 @@
+import { useEffect, useState, useRef } from 'react'
 import { Box } from 'theme-ui'
 import { Chart, Plot, Donut } from '@carbonplan/charts'
 
-const DonutChart = ({ results, maxWidth, center = false }) => {
-  const disabled = results['Total Cost [$/tCO2]'] === 'N/A'
+const DonutChart = ({ results, initWidth, sx }) => {
+  const [width, setWidth] = useState(null)
+  const container = useRef(null)
 
+  const updateWidth = () => {
+    if (container.current) {
+      const newWidth = container.current.offsetWidth
+      if (newWidth < initWidth) {
+        setWidth(newWidth)
+      } else {
+        setWidth(initWidth)
+      }
+    }
+  }
+
+  useEffect(() => {
+    updateWidth()
+  }, [container.current])
+
+  useEffect(() => {
+    window.addEventListener('resize', updateWidth)
+    return () => {
+      window.removeEventListener('resize', updateWidth)
+    }
+  }, [])
+
+  const disabled = results['Total Cost [$/tCO2]'] === 'N/A'
   const values = []
 
   if (disabled) {
@@ -20,24 +45,25 @@ const DonutChart = ({ results, maxWidth, center = false }) => {
   }
 
   return (
-    <Box
-      sx={{
-        width: '100%',
-        maxWidth: center ? undefined : maxWidth,
-        height: maxWidth,
-        ml: center ? undefined : 1,
-      }}
-    >
-      <Chart padding={{ left: 0, bottom: 0 }}>
-        <Plot square>
-          <Donut
-            range={[0.32, 1]}
-            data={values}
-            innerRadius={0.24}
-            color={disabled ? 'gray' : 'purple'}
-          />
-        </Plot>
-      </Chart>
+    <Box ref={container}>
+      <Box
+        sx={{
+          width,
+          height: width,
+          ...sx,
+        }}
+      >
+        <Chart padding={{ left: 0, bottom: 0 }}>
+          <Plot square>
+            <Donut
+              range={[0.32, 1]}
+              data={values}
+              innerRadius={0.23}
+              color={disabled ? 'gray' : 'purple'}
+            />
+          </Plot>
+        </Chart>
+      </Box>
     </Box>
   )
 }

--- a/articles/dac-calculator-explainer/components/parameter-scenario.js
+++ b/articles/dac-calculator-explainer/components/parameter-scenario.js
@@ -51,11 +51,20 @@ const ParameterScenario = ({
           <Divider />
           <Box
             sx={{
-              textAlign: ['left', 'center', 'center'],
-              mt: ['13px', '13px', 4],
+              textAlign: ['left', 'center', 'center', 'center'],
+              mt: ['13px', '13px', '26px', 4],
+              width: ['85%', '85%', '100%', '100%'],
+              margin: 'auto',
             }}
           >
-            <Donut results={results} maxWidth={150} center />
+            <Donut
+              results={results}
+              initWidth={150}
+              sx={{
+                margin: 'auto',
+                mt: '16px',
+              }}
+            />
           </Box>
         </Column>
         <Column start={[4, 5, 5, 5]} width={[3, 2, 2, 2]}>

--- a/articles/dac-calculator-explainer/components/parameter-scenario.js
+++ b/articles/dac-calculator-explainer/components/parameter-scenario.js
@@ -55,7 +55,7 @@ const ParameterScenario = ({
               mt: ['13px', '13px', 4],
             }}
           >
-            <Donut results={results} initWidth={150} />
+            <Donut results={results} maxWidth={150} center />
           </Box>
         </Column>
         <Column start={[4, 5, 5, 5]} width={[3, 2, 2, 2]}>

--- a/articles/dac-calculator-explainer/components/parameter-scenario.js
+++ b/articles/dac-calculator-explainer/components/parameter-scenario.js
@@ -52,8 +52,7 @@ const ParameterScenario = ({
           <Box
             sx={{
               textAlign: ['left', 'center', 'center', 'center'],
-              mt: ['13px', '13px', '26px', 4],
-              width: ['85%', '85%', '100%', '100%'],
+              mt: ['13px', '13px', '26px', '27px'],
               margin: 'auto',
             }}
           >

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/charts": "^2.0.0",
+        "@carbonplan/charts": "^2.1.1",
         "@carbonplan/components": "^10.1.1",
         "@carbonplan/icons": "^1.0.0",
         "@carbonplan/theme": "^7.0.0",
@@ -378,9 +378,9 @@
       }
     },
     "node_modules/@carbonplan/charts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-2.0.0.tgz",
-      "integrity": "sha512-d7UuPV5lmTqS/6sQfvMZMJE62oKG28vdycerGgCRd1TkddhMDIhPy1sKwcKMpzWU2flZNofNvPYu01kcG/H0/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-2.1.1.tgz",
+      "integrity": "sha512-4b7yLwzF/vk7ivVzLoooA1FbSdyUqAqar0fhIFWaR/+Yc65MU/qQKGVanixIPL9Amn3bjHhRBzAO/x3VARjMIA==",
       "dependencies": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"
@@ -6960,9 +6960,9 @@
       }
     },
     "@carbonplan/charts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-2.0.0.tgz",
-      "integrity": "sha512-d7UuPV5lmTqS/6sQfvMZMJE62oKG28vdycerGgCRd1TkddhMDIhPy1sKwcKMpzWU2flZNofNvPYu01kcG/H0/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-2.1.1.tgz",
+      "integrity": "sha512-4b7yLwzF/vk7ivVzLoooA1FbSdyUqAqar0fhIFWaR/+Yc65MU/qQKGVanixIPL9Amn3bjHhRBzAO/x3VARjMIA==",
       "requires": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/carbonplan/research#readme",
   "dependencies": {
-    "@carbonplan/charts": "^2.0.0",
+    "@carbonplan/charts": "^2.1.1",
     "@carbonplan/components": "^10.1.1",
     "@carbonplan/icons": "^1.0.0",
     "@carbonplan/theme": "^7.0.0",

--- a/tools/dac-calculator/components/calculator.js
+++ b/tools/dac-calculator/components/calculator.js
@@ -224,7 +224,7 @@ const Calculator = () => {
                   <Row columns={[3]}>
                     <Column start={[1]} width={[2]}>
                       <Box sx={{ pt: [2], ml: ['-6px'] }}>
-                        <Donut params={{ results: results }}></Donut>
+                        <Donut results={results}></Donut>
                       </Box>
                     </Column>
                   </Row>

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -24,7 +24,7 @@ const Donut = ({ results }) => {
         <Plot square>
           <DonutComponent
             data={values}
-            innerRadius={0.26}
+            innerRadius={0.23}
             color={cost < 0 ? 'gray' : 'purple'}
           />
         </Plot>

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -23,7 +23,6 @@ const DonutChart = ({ results }) => {
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
           <Donut
-            range={[0.32, 1]}
             data={values}
             innerRadius={0.225}
             color={cost < 0 ? 'gray' : 'purple'}

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -1,7 +1,7 @@
 import { Box } from 'theme-ui'
-import { Chart, Plot, Donut as DonutComponent } from '@carbonplan/charts'
+import { Chart, Plot, Donut } from '@carbonplan/charts'
 
-const Donut = ({ results }) => {
+const DonutChart = ({ results }) => {
   const cost = results['Total Cost [$/tCO2 Net Removed]']
 
   const values = []
@@ -22,7 +22,7 @@ const Donut = ({ results }) => {
     <Box sx={{ width: 200, height: 200 }}>
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
-          <DonutComponent
+          <Donut
             data={values}
             innerRadius={0.23}
             color={cost < 0 ? 'gray' : 'purple'}
@@ -33,4 +33,4 @@ const Donut = ({ results }) => {
   )
 }
 
-export default Donut
+export default DonutChart

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -23,6 +23,7 @@ const DonutChart = ({ results }) => {
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
           <Donut
+            range={[0.32, 1]}
             data={values}
             innerRadius={0.23}
             color={cost < 0 ? 'gray' : 'purple'}

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -1,127 +1,34 @@
-import { useEffect, useState, useRef } from 'react'
-import { Vega } from 'react-vega'
-import { useThemeUI, Box } from 'theme-ui'
-var vegaLite = require('vega-lite')
+import { Box } from 'theme-ui'
+import { Chart, Plot, Donut as DonutComponent } from '@carbonplan/charts'
 
-const Donut = ({ params }) => {
-  const [spec, setSpec] = useState(null)
-  const [loaded, setLoaded] = useState(false)
-  const { theme } = useThemeUI()
-  const { secondary, purple } = theme.rawColors
-  const cost = params.results['Total Cost [$/tCO2 Net Removed]']
+const Donut = ({ results }) => {
+  const cost = results['Total Cost [$/tCO2 Net Removed]']
 
-  useEffect(() => {
-    const config = {
-      background: null,
-      cursor: 'pointer',
-      view: {
-        stroke: null,
-      },
+  const values = []
+  if (cost < 0) {
+    values.push(1)
+  } else {
+    values.push(
+      results['Capital Recovery [$/tCO2eq Net Removed]'],
+      results['Fixed O&M [$/tCO2eq Net Removed]'],
+      results['Variable O&M [$/tCO2eq Net Removed]']
+    )
+    if (results['Natural Gas Cost [$/tCO2 Net Removed]'] > 0) {
+      values.push(results['Natural Gas Cost [$/tCO2 Net Removed]'])
     }
-
-    const spec = {
-      data: {
-        name: 'values',
-      },
-      mark: {
-        type: 'arc',
-        innerRadius: 45,
-        color: theme.colors.purple,
-      },
-      encoding: {
-        theta: {
-          field: 'fraction',
-          type: 'quantitative',
-          scale: { domain: [0, 1] },
-        },
-        fillOpacity: {
-          field: 'index',
-          type: 'quantitative',
-          scale: { domain: [0, 3], range: [0.3, 0.9] },
-          legend: null,
-        },
-        color: {
-          field: 'color',
-          type: 'quantitative',
-          scale: {
-            domain: [0, 1],
-            range: [secondary, purple],
-          },
-          legend: null,
-        },
-      },
-    }
-
-    setSpec(vegaLite.compile(spec, { config: config }).spec)
-    setLoaded(true)
-  }, [theme])
-
-  const values = [
-    {
-      category: 'CAPITAL RECOVERY',
-      index: cost < 0 ? 1 : 0,
-      color: cost < 0 ? 0 : 1,
-      value: params.results['Capital Recovery [$/tCO2eq Net Removed]'],
-      fraction:
-        cost < 0
-          ? 1
-          : params.results['Capital Recovery [$/tCO2eq Net Removed]'] /
-            params.results['Total Cost [$/tCO2 Net Removed]'],
-    },
-    {
-      category: 'FIXED O&M',
-      index: cost < 0 ? 1 : 1,
-      color: cost < 0 ? 0 : 1,
-      value: params.results['Fixed O&M [$/tCO2eq Net Removed]'],
-      fraction:
-        cost < 0
-          ? 0
-          : params.results['Fixed O&M [$/tCO2eq Net Removed]'] /
-            params.results['Total Cost [$/tCO2 Net Removed]'],
-    },
-    {
-      category: 'VARIABLE O&M',
-      index: cost < 0 ? 1 : 3,
-      color: cost < 0 ? 0 : 1,
-      value: params.results['Variable O&M [$/tCO2eq Net Removed]'],
-      fraction:
-        cost < 0
-          ? 0
-          : params.results['Variable O&M [$/tCO2eq Net Removed]'] /
-            params.results['Total Cost [$/tCO2 Net Removed]'],
-    },
-  ]
-
-  if (params.results['Natural Gas Cost [$/tCO2 Net Removed]'] > 0) {
-    values.push({
-      category: 'NATURAL GAS',
-      index: cost < 0 ? 1 : 2,
-      color: cost < 0 ? 0 : 1,
-      value: params.results['Natural Gas Cost [$/tCO2 Net Removed]'],
-      fraction:
-        cost < 0
-          ? 0
-          : params.results['Natural Gas Cost [$/tCO2 Net Removed]'] /
-            params.results['Total Cost [$/tCO2 Net Removed]'],
-    })
   }
 
-  const width = 200
-  const height = 200
-
   return (
-    <Box>
-      {loaded && (
-        <Vega
-          width={width}
-          height={height}
-          data={{ values: values }}
-          renderer={'svg'}
-          actions={false}
-          spec={spec}
-        />
-      )}
-      {!loaded && <Box sx={{ height: height + 14 }}></Box>}
+    <Box sx={{ width: 200, height: 200 }}>
+      <Chart padding={{ left: 0, bottom: 0 }}>
+        <Plot square>
+          <DonutComponent
+            data={values}
+            innerRadius={0.26}
+            color={cost < 0 ? 'gray' : 'purple'}
+          />
+        </Plot>
+      </Chart>
     </Box>
   )
 }

--- a/tools/dac-calculator/components/charts/donut.js
+++ b/tools/dac-calculator/components/charts/donut.js
@@ -19,13 +19,13 @@ const DonutChart = ({ results }) => {
   }
 
   return (
-    <Box sx={{ width: 200, height: 200 }}>
+    <Box sx={{ width: 200, height: 200, mt: '4px', ml: '5px', mb: '10px' }}>
       <Chart padding={{ left: 0, bottom: 0 }}>
         <Plot square>
           <Donut
             range={[0.32, 1]}
             data={values}
-            innerRadius={0.23}
+            innerRadius={0.225}
             color={cost < 0 ? 'gray' : 'purple'}
           />
         </Plot>


### PR DESCRIPTION
Replace `vega` donut charts in DAC cost calculator explainer and tool with `@carbonplan/charts` version

### Tool
#### Before
<img width="279" alt="Screen Shot 2021-11-16 at 2 50 24 PM" src="https://user-images.githubusercontent.com/12436887/142078908-197630bb-0c72-4c4d-b07a-c70d3e6a1ae1.png">

#### Aft
<img width="274" alt="Screen Shot 2021-11-16 at 2 50 16 PM" src="https://user-images.githubusercontent.com/12436887/142078904-64c7828e-c02a-4ade-9098-ecbc0812bbb5.png">
er

### Explainer
#### Before
<img width="1446" alt="Screen Shot 2021-11-16 at 2 53 11 PM" src="https://user-images.githubusercontent.com/12436887/142079132-eec6fd50-b670-4294-bc5b-4b915d2070ea.png">

<img width="1445" alt="Screen Shot 2021-11-16 at 2 54 04 PM" src="https://user-images.githubusercontent.com/12436887/142079197-272c0565-6ce7-4560-b9a2-3d5ccaec880b.png">

#### After
<img width="1452" alt="Screen Shot 2021-11-16 at 2 53 36 PM" src="https://user-images.githubusercontent.com/12436887/142079148-897d8c59-ec31-474a-ae6c-a73e1e7637bd.png">

<img width="1441" alt="Screen Shot 2021-11-16 at 2 54 12 PM" src="https://user-images.githubusercontent.com/12436887/142079211-03d35957-e8f7-4487-bb90-ea0e91eb61c6.png">


