### PR TITLE
support user input

### DIFF
--- a/tools/permanence-calculator/components/calculator.js
+++ b/tools/permanence-calculator/components/calculator.js
@@ -9,9 +9,9 @@ import Cost from './cost'
 
 const Calculator = () => {
   const initOptions = {
-    discountRate: 0.03,
+    discountRate: 3,
     shortDuration: 10,
-    projectRisk: 0.1,
+    projectRisk: 10,
     switchingTime: 50,
     switchingTimeActive: true,
     horizon: 1000,
@@ -174,8 +174,8 @@ const Calculator = () => {
                 value={get('discountRate')}
                 setValue={set('discountRate')}
                 min={0}
-                max={0.1}
-                step={0.001}
+                max={10}
+                step={0.1}
               />
               <Slider
                 name='project risk'
@@ -184,8 +184,8 @@ const Calculator = () => {
                 value={get('projectRisk')}
                 setValue={set('projectRisk')}
                 min={0}
-                max={0.1}
-                step={0.001}
+                max={10}
+                step={0.1}
               />
               <Curve
                 name='temporary cost'
@@ -193,16 +193,20 @@ const Calculator = () => {
                 units='$/tCO₂ (initial)'
                 value={get('shortCostCurve')}
                 setValue={set('shortCostCurve')}
-                displayValue={shortCostDisplay()}
+                displayMethod={shortCostDisplay()}
                 scales={{ x: [0, 100], y: [0, 100] }}
               />
               <Curve
                 name='permanent cost'
                 description='What is the cost of permanent carbon removal over time?'
-                units='$/tCO₂ (switch time)'
+                units={
+                  options['switchingTimeActive']
+                    ? '$/tCO₂ (switch time)'
+                    : '$/tCO₂ (initial)'
+                }
                 value={get('longCostCurve')}
                 setValue={set('longCostCurve')}
-                displayValue={longCostDisplay()}
+                displayMethod={longCostDisplay()}
                 scales={{ x: [0, 100], y: [0, 1000] }}
               />
             </Box>

--- a/tools/permanence-calculator/components/charts/cost-curve.js
+++ b/tools/permanence-calculator/components/charts/cost-curve.js
@@ -108,11 +108,19 @@ const CostCurve = (container, theme, value, setValue, name, scales, fixed) => {
     .attr('stroke-width', 2)
     .attr('d', createLine)
 
-  focus
-    .selectAll('.' + className)
-    .data(points)
-    .enter()
-    .append('circle')
+  let circles
+
+  if (fixed) {
+    circles = focus.append('circle').datum(points[0])
+  } else {
+    circles = focus
+      .selectAll('.' + className)
+      .data(points)
+      .enter()
+      .append('circle')
+  }
+
+  circles
     .attr('r', 8.0)
     .attr('cx', function (d) {
       return x(d[0])
@@ -124,7 +132,7 @@ const CostCurve = (container, theme, value, setValue, name, scales, fixed) => {
     .style('cursor', 'pointer')
     .style('fill', theme.colors.pink)
 
-  focus.selectAll('.' + className).call(dragger)
+  circles.call(dragger)
 
   svg
     .append('text')
@@ -201,6 +209,7 @@ const CostCurve = (container, theme, value, setValue, name, scales, fixed) => {
         [0, d[1]],
         [100, d[1]],
       ])
+      circles.datum([50, d[1]])
     }
     current
       .attr('x', x(d[0]))
@@ -216,7 +225,24 @@ const CostCurve = (container, theme, value, setValue, name, scales, fixed) => {
     current.style('opacity', 0)
   }
 
-  const update = (data) => {}
+  const update = (v) => {
+    if (fixed) {
+      points = [[50, Math.min(v, scales.y[1])]]
+      pathPoints = [
+        [0, Math.min(v, scales.y[1])],
+        [100, Math.min(v, scales.y[1])],
+      ]
+    }
+    path.datum(pathPoints).attr('d', createLine)
+    circles
+      .datum(points[0])
+      .attr('cx', function (d) {
+        return x(d[0])
+      })
+      .attr('cy', function (d) {
+        return y(d[1])
+      })
+  }
 
   return { update: update }
 }

--- a/tools/permanence-calculator/components/controls/curve.js
+++ b/tools/permanence-calculator/components/controls/curve.js
@@ -1,11 +1,9 @@
 import { useRef, useState, useEffect } from 'react'
 import { useThemeUI, Box, Grid, Slider } from 'theme-ui'
 import { darken } from '@theme-ui/color'
-import { Row, Column } from '@carbonplan/components'
+import { Row, Column, Input } from '@carbonplan/components'
 import LabeledToggle from '../labeled-toggle'
 import CostCurve from '../charts/cost-curve'
-
-let chart = null
 
 const Curve = ({
   name,
@@ -13,15 +11,17 @@ const Curve = ({
   units,
   value,
   setValue,
-  displayValue,
   scales,
+  displayMethod,
 }) => {
   const container = useRef(null)
   const { theme } = useThemeUI()
+  const [chart, setChart] = useState(null)
   const [isVariable, setIsVariable] = useState(false)
+  const [displayValue, setDisplayValue] = useState(value[0][1])
 
-  useEffect(() => {
-    chart = new CostCurve(
+  const initializeChart = () => {
+    const out = new CostCurve(
       container,
       theme,
       value,
@@ -30,6 +30,12 @@ const Curve = ({
       scales,
       !isVariable
     )
+
+    setChart(out)
+  }
+
+  useEffect(() => {
+    initializeChart()
 
     return function cleanup() {
       container.current.innerHTML = ''
@@ -43,15 +49,7 @@ const Curve = ({
       clearTimeout(id)
       id = setTimeout(() => {
         if (container.current.offsetWidth > 0) {
-          chart = new CostCurve(
-            container,
-            theme,
-            value,
-            setValue,
-            name,
-            scales,
-            !isVariable
-          )
+          initializeChart()
         }
       }, 150)
     }
@@ -61,11 +59,53 @@ const Curve = ({
     return () => {
       window.removeEventListener('resize', listener)
     }
-  }, [theme])
+  }, [theme, isVariable, value])
 
   const format = (value) => {
-    return `$${value.toFixed(0)}`
+    return `$${value}`
   }
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    updateParamValueFromInput()
+  }
+
+  const updateParamValueFromInput = () => {
+    let v = parseInt(displayValue)
+    if (!isNaN(v)) {
+      if (v < 0) {
+        v = 0
+      }
+      if (v > 5000) {
+        v = 5000
+      }
+      setValue([
+        [0, v],
+        [20, v],
+        [40, v],
+        [60, v],
+        [80, v],
+        [100, v],
+      ])
+      setDisplayValue(v)
+      if (!isVariable && chart) chart.update(v)
+    } else {
+      setDisplayValue(parseInt(value[0][1]))
+    }
+  }
+
+  const updateParamDisplayValue = (e) => {
+    let normalized = e.target.value.replace('$', '')
+    setDisplayValue(normalized)
+  }
+
+  useEffect(() => {
+    if (!isVariable) {
+      setDisplayValue(parseInt(value[0][1]))
+    } else {
+      setDisplayValue(parseInt(displayMethod))
+    }
+  }, [value])
 
   return (
     <Box
@@ -117,28 +157,26 @@ const Curve = ({
       </Row>
       <Row columns={[6, 6, 5, 5]}>
         <Column start={[1]} width={[2, 1, 1, 1]}>
-          <Box
-            sx={{
-              borderStyle: 'solid',
-              borderColor: 'primary',
-              borderWidth: '0px',
-              borderBottomWidth: '1px',
-              pb: [1],
-              pt: [2],
-            }}
-          >
-            <Box
+          <form onSubmit={handleSubmit}>
+            <Input
+              type='text'
+              size='md'
               sx={{
-                display: 'inline-block',
+                textAlign: 'left',
                 color: 'pink',
-                fontSize: [4],
                 fontFamily: 'mono',
                 letterSpacing: 'mono',
+                transition: '0.2s',
+                width: '100%',
+                pb: [1],
+                pt: ['12px'],
               }}
-            >
-              {format(displayValue)}
-            </Box>
-          </Box>
+              onChange={updateParamDisplayValue}
+              onBlur={updateParamValueFromInput}
+              value={format(displayValue)}
+              disabled={isVariable ? true : false}
+            />
+          </form>
           <Box
             sx={{
               color: 'secondary',
@@ -152,7 +190,7 @@ const Curve = ({
           </Box>
         </Column>
         <Column start={[3, 2, 2, 2]} width={[5, 5, 4, 4]}>
-          <Box sx={{ mt: ['5px'], ml: ['-10px'] }}>
+          <Box sx={{ mt: ['9px', '9px', '9px', '11px'], ml: ['-10px'] }}>
             <Box ref={container} sx={{ height: '200px', width: '100%' }} />
           </Box>
         </Column>

--- a/tools/permanence-calculator/components/controls/curve.js
+++ b/tools/permanence-calculator/components/controls/curve.js
@@ -76,8 +76,8 @@ const Curve = ({
       if (v < 0) {
         v = 0
       }
-      if (v > 5000) {
-        v = 5000
+      if (v > 9999) {
+        v = 9999
       }
       setValue([
         [0, v],

--- a/tools/permanence-calculator/components/controls/slider.js
+++ b/tools/permanence-calculator/components/controls/slider.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useThemeUI, Box } from 'theme-ui'
-import { Row, Column, Slider } from '@carbonplan/components'
+import { Input, Row, Column, Slider } from '@carbonplan/components'
 import LabeledToggle from '../labeled-toggle'
 import { darken } from '@theme-ui/color'
 
@@ -20,15 +20,17 @@ const Control = ({
   max = max ? max : 1
   step = step ? step : 0.1
 
+  const [displayValue, setDisplayValue] = useState(value)
+
   const format = (value) => {
     if (units == 'dollars') {
       return `$${value.toFixed(0)}`
     } else if (name == 'discount rate') {
-      return `${(value * 100).toFixed(1)}%`
+      return `${value}%`
     } else if (name == 'project risk') {
-      return `${(value * 100).toFixed(1)}%`
+      return `${value}%`
     } else {
-      return value.toFixed(0)
+      return value
     }
   }
 
@@ -42,6 +44,43 @@ const Control = ({
       setOptional(active)
     }
   }, [active])
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    updateParamValueFromInput()
+  }
+
+  const updateParamValueFromInput = () => {
+    let v = parseFloat(displayValue)
+    if (!isNaN(v)) {
+      if (v < min) {
+        v = min
+      }
+      if (v > max) {
+        v = max
+      }
+      setValue(v)
+      setDisplayValue(v)
+    } else {
+      setDisplayValue(value)
+    }
+  }
+
+  const updateParamValue = (e) => {
+    setValue(parseFloat(e.target.value))
+  }
+
+  const updateParamDisplayValue = (e) => {
+    let normalized = e.target.value
+    if (name === 'discount rate' || name === 'project risk') {
+      normalized = normalized.replace('%', '')
+    }
+    setDisplayValue(normalized)
+  }
+
+  useEffect(() => {
+    setDisplayValue(value)
+  }, [value])
 
   return (
     <Box
@@ -95,29 +134,25 @@ const Control = ({
       </Row>
       <Row columns={[6, 6, 5, 5]}>
         <Column start={[1]} width={[2, 1, 1, 1]}>
-          <Box
-            sx={{
-              borderStyle: 'solid',
-              borderColor: 'primary',
-              borderWidth: '0px',
-              borderBottomWidth: '1px',
-              pb: [1],
-              pt: [2],
-            }}
-          >
-            <Box
+          <form onSubmit={handleSubmit}>
+            <Input
+              type='text'
+              size='md'
               sx={{
-                display: 'inline-block',
+                textAlign: 'left',
                 color: active ? 'pink' : 'muted',
-                fontSize: [4],
                 fontFamily: 'mono',
-                letterSpacing: '0.03em',
+                letterSpacing: 'mono',
                 transition: '0.2s',
+                width: '100%',
+                pb: [1],
+                pt: ['12px'],
               }}
-            >
-              {format(value)}
-            </Box>
-          </Box>
+              onChange={updateParamDisplayValue}
+              onBlur={updateParamValueFromInput}
+              value={format(displayValue)}
+            />
+          </form>
           <Box
             sx={{
               color: 'secondary',
@@ -136,11 +171,11 @@ const Control = ({
               width: ['100%'],
               color: active ? 'pink' : 'muted',
               backgroundColor: active ? 'secondary' : 'muted',
-              mt: ['42px'],
+              mt: ['42px', '42px', '42px', '55px'],
               pointerEvents: active ? 'all' : 'none',
             }}
             value={value}
-            onChange={(e) => setValue(parseFloat(e.target.value))}
+            onChange={updateParamValue}
             min={min}
             max={max}
             step={step}

--- a/tools/permanence-calculator/components/cost.js
+++ b/tools/permanence-calculator/components/cost.js
@@ -24,7 +24,7 @@ const Cost = ({
   const years = Array(horizon + shortDuration)
     .fill(0)
     .map((_, i) => i)
-  const discount = years.map((y) => 1 / Math.pow(1 + discountRate, y))
+  const discount = years.map((y) => 1 / Math.pow(1 + discountRate / 100, y))
 
   const simulate = () => {
     let counter = 0
@@ -57,7 +57,7 @@ const Cost = ({
   const projectFail = () => {
     let counter = 1
     while (counter < shortDuration) {
-      if (Math.random() < projectRisk) {
+      if (Math.random() < projectRisk / 100) {
         return counter
       } else {
         counter += 1
@@ -121,7 +121,7 @@ const Cost = ({
       <Box
         sx={{
           display: ['inline-block', 'inline-block', 'block'],
-          fontSize: [3, 3, 6, 7],
+          fontSize: [4, 4, 6, 7],
           fontFamily: 'mono',
           letterSpacing: '0.02em',
           color: 'pink',
@@ -157,7 +157,7 @@ const Cost = ({
       <Box
         sx={{
           display: ['inline-block', 'inline-block', 'block'],
-          fontSize: [3, 3, 6, 7],
+          fontSize: [4, 4, 6, 7],
           fontFamily: 'mono',
           letterSpacing: '0.02em',
           color: 'pink',

--- a/tools/permanence-calculator/components/timeline.js
+++ b/tools/permanence-calculator/components/timeline.js
@@ -20,7 +20,7 @@ const Timeline = ({ options }) => {
     const years = Array(101)
       .fill(0)
       .map((_, i) => i)
-    const discount = years.map((y) => 1 / Math.pow(1 + discountRate, y))
+    const discount = years.map((y) => 1 / Math.pow(1 + discountRate / 100, y))
 
     const discountFunction = years.map((year) => {
       return {


### PR DESCRIPTION
This PR adds support for entering arbitrary inputs into the values of the permanence calculator.

This turned out to be a bit subtle in places, so a couple notes on the functionality:

- All inputs respect their intended formatting (e.g. appending a `%` or `$`)

- I reparameterized two fractions (project risk and discount rate) in the model as percentages, because it only required a couple changes to the model (dividing by 100 in a couple places), and made the handling / formatting of the inputs much easier.

- For the cost curves, when "curve mode" is turned on, the input is disabled, because it's not obvious what the single input ought to do, so it felt cleanest to just turn off the ability to enter a value and avoid the potential for confusion.

- The cost curve chart needed a new `update` method so that changes from the input could propagate through (previously the chart only updated while interacting with the chart via dragging, so it was handled internally).

There's a fairly common pattern we've now used in a couple places (here and DAC calculator) that connects our `Input` component to some state handling, to cleanly handle updates and separate an underlying value from a displayed value. Might be worth looking at pulling that out (cc @katamartin ).