### PR TITLE
[bugfix] Gray out bars for NaN values in DAC calculator

### DIFF
--- a/tools/dac-calculator/components/charts/param-chart.js
+++ b/tools/dac-calculator/components/charts/param-chart.js
@@ -5,6 +5,7 @@ import {
   Ticks,
   TickLabels,
   Plot,
+  Bar,
   StackedBar,
 } from '@carbonplan/charts'
 
@@ -18,6 +19,18 @@ const ParamChart = ({ param, data }) => {
             (param.validRange[1] - param.validRange[0]) * 0.04,
         ]
       : param.displayRange
+
+  const { validValues, invalidValues } = data.reduce(
+    (accum, [x, ...yValues]) => {
+      if (yValues.find((v) => v === 1000)) {
+        accum.invalidValues.push([x, 1000])
+      } else {
+        accum.validValues.push([x, 0, ...yValues])
+      }
+      return accum
+    },
+    { validValues: [], invalidValues: [] }
+  )
 
   return (
     <Box
@@ -39,11 +52,17 @@ const ParamChart = ({ param, data }) => {
         <TickLabels right format={(d) => `$${d}`} />
         <TickLabels bottom values={param.tickLabels} />
         <Plot>
-          <StackedBar
-            data={data.map(([x, ...yValues]) => [x, 0, ...yValues])}
-            color='purple'
-            width={param.width}
-          />
+          {validValues.length > 0 && (
+            <StackedBar data={validValues} color='purple' width={param.width} />
+          )}
+          {invalidValues.length > 0 && (
+            <Bar
+              data={invalidValues}
+              color='secondary'
+              sx={{ opacity: 0.9 }}
+              width={param.width}
+            />
+          )}
         </Plot>
       </Chart>
     </Box>

--- a/tools/dac-calculator/components/charts/param-chart.js
+++ b/tools/dac-calculator/components/charts/param-chart.js
@@ -59,7 +59,7 @@ const ParamChart = ({ param, data }) => {
             <Bar
               data={invalidValues}
               color='secondary'
-              sx={{ opacity: 0.9 }}
+              fillOpacity={0.6}
               width={param.width}
             />
           )}

--- a/tools/dac-calculator/components/charts/param-chart.js
+++ b/tools/dac-calculator/components/charts/param-chart.js
@@ -22,7 +22,7 @@ const ParamChart = ({ param, data }) => {
 
   const { validValues, invalidValues } = data.reduce(
     (accum, [x, ...yValues]) => {
-      if (yValues.find((v) => v === 1000)) {
+      if (yValues.find((v) => v < 0)) {
         accum.invalidValues.push([x, 1000])
       } else {
         accum.validValues.push([x, 0, ...yValues])

--- a/tools/dac-calculator/components/model/partial-cost.js
+++ b/tools/dac-calculator/components/model/partial-cost.js
@@ -82,7 +82,7 @@ function calcForOneParam(model, p, params) {
       results['Capital Recovery [$/tCO2eq Net Removed]'],
     ].reduce((accum, el, i) => {
       if (results['Total Cost [$/tCO2 Net Removed]'] < 0) {
-        accum.push(1000)
+        accum.push(-1)
       } else if (i < 1) {
         accum.push(el)
       } else {
@@ -125,7 +125,7 @@ function calcForOneTechParam(model, tech, p, params) {
       results['Capital Recovery [$/tCO2eq Net Removed]'],
     ].reduce((accum, el, i) => {
       if (results['Total Cost [$/tCO2 Net Removed]'] < 0) {
-        accum.push(1000)
+        accum.push(-1)
       } else if (i < 1) {
         accum.push(el)
       } else {


### PR DESCRIPTION
Fixes https://github.com/carbonplan/research/issues/195

This PR restores the previous behavior in the DAC calculator where bars for any parameter value that would result in a NaN result gray out. This is now achieved by:
- explicitly returning a negative y-value for invalid cost result
- filtering negative values in `ParamChart` and rendering data in a separate grayed-out `Bar` chart

<img width="1089" alt="Screen Shot 2021-11-30 at 9 17 19 AM" src="https://user-images.githubusercontent.com/12436887/144095732-db97f1fc-1317-4c27-a12b-b3457b5aa5e0.png">
