### PR TITLE
update charts to fix scatter plots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@carbonplan/charts": "^3.0.0",
+        "@carbonplan/charts": "^3.1.1",
         "@carbonplan/colormaps": "^4.0.0",
         "@carbonplan/components": "^12.5.0",
         "@carbonplan/emoji": "^2.0.0",
@@ -555,9 +555,9 @@
       "dev": true
     },
     "node_modules/@carbonplan/charts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.0.0.tgz",
-      "integrity": "sha512-7l4Q2EaYHdekY0uGz2ZE5PS4WR79eTflDCA96CVmROpnQVyaAQETvcW/5lEk/0HcRBBUBgxVVcEZX4J8yIHESQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.1.1.tgz",
+      "integrity": "sha512-/B/1EdQ43dWmSvRmOnFpOUqJXlM61EH1u0b3ixJzuonyaMokN1oDfkV1NpPQF2ZJkhW1NwUEBwTY/X2BKUs7rg==",
       "dependencies": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"
@@ -10659,9 +10659,9 @@
       "dev": true
     },
     "@carbonplan/charts": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.0.0.tgz",
-      "integrity": "sha512-7l4Q2EaYHdekY0uGz2ZE5PS4WR79eTflDCA96CVmROpnQVyaAQETvcW/5lEk/0HcRBBUBgxVVcEZX4J8yIHESQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@carbonplan/charts/-/charts-3.1.1.tgz",
+      "integrity": "sha512-/B/1EdQ43dWmSvRmOnFpOUqJXlM61EH1u0b3ixJzuonyaMokN1oDfkV1NpPQF2ZJkhW1NwUEBwTY/X2BKUs7rg==",
       "requires": {
         "d3-scale": "^3.3.0",
         "d3-shape": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/carbonplan/research#readme",
   "prettier": "@carbonplan/prettier",
   "dependencies": {
-    "@carbonplan/charts": "^3.0.0",
+    "@carbonplan/charts": "^3.1.1",
     "@carbonplan/colormaps": "^4.0.0",
     "@carbonplan/components": "^12.5.0",
     "@carbonplan/emoji": "^2.0.0",


### PR DESCRIPTION
tested all articles that contain a `<Scatter>` component in safari. I'm seeing all expected points after this update, where live versions are missing most or all points. 