### PR TITLE
fix forest-offsets-explainer links to map tool

### DIFF
--- a/articles/forest-offsets-explainer/components/project-analysis/index.js
+++ b/articles/forest-offsets-explainer/components/project-analysis/index.js
@@ -468,7 +468,7 @@ const ProjectAnalysis = () => {
             </Box>
             <Button
               size='xs'
-              href={`/research/forest-offsets?id=${selected}`}
+              href={`/research/forest-offsets-crediting?id=${selected}`}
               inverted
               suffix={<RotatingArrow />}
               sx={{

--- a/articles/forest-offsets-explainer/components/southern-cascades/info.js
+++ b/articles/forest-offsets-explainer/components/southern-cascades/info.js
@@ -109,7 +109,7 @@ const Info = ({ project, mobile = false }) => {
       <Button
         size='xs'
         inverted
-        href={`/research/forest-offsets?id=${id}`}
+        href={`/research/forest-offsets-crediting?id=${id}`}
         suffix={<RotatingArrow />}
         sx={{
           cursor: 'pointer',

--- a/contents/publications.js
+++ b/contents/publications.js
@@ -99,7 +99,7 @@ const publications = [
         label: 'Explainer article',
         href: '/research/forest-offsets-explainer',
       },
-      { label: 'Map tool', href: '/research/forest-offsets' },
+      { label: 'Map tool', href: '/research/forest-offsets-crediting' },
       {
         label: 'Press coverage',
         href: 'https://www.propublica.org/article/the-climate-solution-actually-adding-millions-of-tons-of-co2-into-the-atmosphere',


### PR DESCRIPTION
Was reading our [article](https://carbonplan.org/research/forest-offsets-explainer) on offsets over-crediting and noticed that the links out to the map tool from the figures were pointing to the wrong place. This makes them work again! Also updated the link to the tool in the publications section.