### PR TITLE
improve dynamic (commentary) social card caching 

### DIFF
--- a/pages/api/og/commentary.page.js
+++ b/pages/api/og/commentary.page.js
@@ -39,6 +39,14 @@ export default async function handler(req) {
     return new ImageResponse(component, {
       ...options,
       fonts,
+      headers: {
+        // Vercel's CDN only caches functions on `s-maxage`; the deployment URL
+        // is part of the cache key, so a redeploy refreshes these cards.
+        'Vercel-CDN-Cache-Control':
+          'public, s-maxage=31536000, stale-while-revalidate=86400',
+        // Keep browsers revalidating since the id-based URL is stable.
+        'cache-control': 'public, max-age=0, must-revalidate',
+      },
     })
   } catch (error) {
     console.log(`${error.message}`)


### PR DESCRIPTION
We weren't getting cache hits on the dynamic OG cards, so the edge function re-rendered the image on every request and crashed out when bots swarmed. next/og only sets `max-age`, but Vercel's CDN only caches functions that set `s-maxage`, so nothing was sticking. https://vercel.com/docs/caching/cdn-cache#using-vercel-functions

Card content only changes on a redeploy and the deployment is part of the cache key, so redeploys should refresh everything if needed.

seems like it's working here: https://vercel.com/carbonplan/research/logs?search=deploymentId%3Adpl_5dMv3cN4Jjsi8U672Wf28zgV2vsw+cache%3AHIT&refreshedAt=1784824014305